### PR TITLE
Support ${git:message}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,11 @@ export default class ServerlessGitVariables {
       case 'branch':
         value = await _exec('git rev-parse --abbrev-ref HEAD')
         break
+      case 'message':
+        value = await _exec('git log -1 --pretty=%B')
+        break
       default:
-        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'sha1', 'branch'`)
+        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'sha1', 'branch', 'message'`)
     }
 
     // TODO: Figure out why if I don't log, the deasync promise

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,12 +59,14 @@ test.serial('Inserts variables', async t => {
   sls.service.custom.sha1 = '${git:sha1}' // eslint-disable-line
   sls.service.custom.branch = '${git:branch}' // eslint-disable-line
   sls.service.custom.describe2 = '${git:describe}' // eslint-disable-line
+  sls.service.custom.message = '${git:message}' // eslint-disable-line
   await sls.variables.populateService()
 
   t.is(sls.service.custom.sha1, '90440bd')
   t.is(sls.service.custom.branch, 'another_branch')
   t.is(sls.service.custom.describe, 'my_tag-1-g90440bd')
   t.is(sls.service.custom.describe2, 'my_tag-1-g90440bd')
+  t.is(sls.service.custom.message, 'Another commit')
 })
 
 test('Returns cached value as promise', async t => {


### PR DESCRIPTION
I don't really have the setup to test this, but I followed existing patterns, and `git log -1 --pretty=%B` is correct when run directly in the shell.